### PR TITLE
Added dedicated claim dialect support

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.google/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.google/pom.xml
@@ -77,6 +77,7 @@
                             org.apache.commons.lang; version="${commons-lang.wso2.osgi.version.range}",
                             org.apache.commons.logging; version="${commons-logging.osgi.version.range}",
                             org.apache.commons.codec.binary; version="${commons-codec.wso2.osgi.version.range}",
+                            org.apache.commons.logging.*; version="${commons-logging.osgi.version.range}",
 
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",

--- a/components/org.wso2.carbon.identity.application.authenticator.google/src/main/java/org/wso2/carbon/identity/application/authenticator/google/GoogleOAuth2AuthenticationConstant.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.google/src/main/java/org/wso2/carbon/identity/application/authenticator/google/GoogleOAuth2AuthenticationConstant.java
@@ -29,4 +29,7 @@ public class GoogleOAuth2AuthenticationConstant {
     public static final String GOOGLE_SCOPE = "openid email profile";
     public static final String CALLBACK_URL = "Google-callback-url";
     public static final String ADDITIONAL_QUERY_PARAMS = "AdditionalQueryParameters";
+
+    public static final String OIDC_CLAIM_DIALECT_URI = "http://wso2.org/oidc/claim";
+    public static final String PARAMETER_VALUE_FOR_CLAIM_DIALECT = "GoogleClaimDialectUri";
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.google/src/main/java/org/wso2/carbon/identity/application/authenticator/google/GoogleOAuth2Authenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.google/src/main/java/org/wso2/carbon/identity/application/authenticator/google/GoogleOAuth2Authenticator.java
@@ -237,7 +237,8 @@ public class GoogleOAuth2Authenticator extends OpenIDConnectAuthenticator {
            }
         } else {
             if (log.isDebugEnabled()) {
-                log.debug("Error Reading Parameters for connector " + getName());
+                log.debug("FileBasedConfigBuilder returned null AuthenticatorConfigs for the connector " +
+                        getName());
             }
         }
         return claimDialectUri;

--- a/components/org.wso2.carbon.identity.application.authenticator.google/src/main/java/org/wso2/carbon/identity/application/authenticator/google/GoogleOAuth2Authenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.google/src/main/java/org/wso2/carbon/identity/application/authenticator/google/GoogleOAuth2Authenticator.java
@@ -18,7 +18,11 @@
 package org.wso2.carbon.identity.application.authenticator.google;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.oltu.oauth2.client.response.OAuthClientResponse;
+import org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilder;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authenticator.oidc.OIDCAuthenticatorConstants;
 import org.wso2.carbon.identity.application.authenticator.oidc.OpenIDConnectAuthenticator;
@@ -32,6 +36,7 @@ import java.util.Map;
 public class GoogleOAuth2Authenticator extends OpenIDConnectAuthenticator {
 
     private static final long serialVersionUID = -4154255583070524018L;
+    private static Log log = LogFactory.getLog(GoogleOAuth2Authenticator.class);
     private String tokenEndpoint;
     private String oAuthEndpoint;
     private String userInfoURL;
@@ -214,5 +219,27 @@ public class GoogleOAuth2Authenticator extends OpenIDConnectAuthenticator {
     @Override
     public String getName() {
         return GoogleOAuth2AuthenticationConstant.GOOGLE_CONNECTOR_NAME;
+    }
+
+    @Override
+    public String getClaimDialectURI() {
+        String claimDialectUri = GoogleOAuth2AuthenticationConstant.OIDC_CLAIM_DIALECT_URI;
+        AuthenticatorConfig authConfig = FileBasedConfigurationBuilder.getInstance().getAuthenticatorBean(getName());
+        if (authConfig != null) {
+           Map<String, String> parameters = authConfig.getParameterMap();
+           if (parameters != null && parameters.containsKey(GoogleOAuth2AuthenticationConstant.
+                   PARAMETER_VALUE_FOR_CLAIM_DIALECT)) {
+               claimDialectUri = parameters.get(GoogleOAuth2AuthenticationConstant.PARAMETER_VALUE_FOR_CLAIM_DIALECT);
+           } else {
+               if (log.isDebugEnabled()) {
+                   log.debug("Found no Parameter map for connector " + getName());
+               }
+           }
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("Error Reading Parameters for connector " + getName());
+            }
+        }
+        return claimDialectUri;
     }
 }


### PR DESCRIPTION
The PR is intended to add dedicated claim dialect support for Google-OpenID connector. The existing connector use OIDC standard claim dialect, which leads to claim transformation problems, when mapping is changed according to a specific party. Please see Jira issue :- https://wso2.org/jira/browse/IDENTITY-6239

Propose solution is to read a new configuration from application-authentication.xml. Like below,
ex:- `<Parameter name="GoogleClaimDialectUri">https://wso2.org/google/claims</Parameter>`