### PR TITLE
Added dedicated claim dialect support without changing the authentication framework 

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.google/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.google/pom.xml
@@ -77,7 +77,6 @@
                             org.apache.commons.lang; version="${commons-lang.wso2.osgi.version.range}",
                             org.apache.commons.logging; version="${commons-logging.osgi.version.range}",
                             org.apache.commons.codec.binary; version="${commons-codec.wso2.osgi.version.range}",
-                            org.apache.commons.logging.*; version="${commons-logging.osgi.version.range}",
 
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",

--- a/components/org.wso2.carbon.identity.application.authenticator.google/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.google/pom.xml
@@ -91,7 +91,8 @@
                             org.wso2.carbon.identity.core.util;
                             version="${carbon.identity.framework.package.import.version.range}",
 
-                            org.wso2.carbon.ui; version="${carbon.kernel.package.import.version.range}"
+                            org.wso2.carbon.ui; version="${carbon.kernel.package.import.version.range}",
+                            net.minidev.json; version="${net.minidev.json.imp.pkg.version.range}",
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.application.authenticator.google.internal,

--- a/components/org.wso2.carbon.identity.application.authenticator.google/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.google/pom.xml
@@ -77,6 +77,7 @@
                             org.apache.commons.lang; version="${commons-lang.wso2.osgi.version.range}",
                             org.apache.commons.logging; version="${commons-logging.osgi.version.range}",
                             org.apache.commons.codec.binary; version="${commons-codec.wso2.osgi.version.range}",
+                            org.apache.commons.logging.*; version="${commons-logging.osgi.version.range}",
 
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",

--- a/components/org.wso2.carbon.identity.application.authenticator.google/src/main/java/org/wso2/carbon/identity/application/authenticator/google/GoogleOAuth2AuthenticationConstant.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.google/src/main/java/org/wso2/carbon/identity/application/authenticator/google/GoogleOAuth2AuthenticationConstant.java
@@ -29,7 +29,5 @@ public class GoogleOAuth2AuthenticationConstant {
     public static final String GOOGLE_SCOPE = "openid email profile";
     public static final String CALLBACK_URL = "Google-callback-url";
     public static final String ADDITIONAL_QUERY_PARAMS = "AdditionalQueryParameters";
-
-    public static final String OIDC_CLAIM_DIALECT_URI = "http://wso2.org/oidc/claim";
     public static final String CLAIM_DIALECT_URI_PARAMETER = "GoogleClaimDialectUri";
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.google/src/main/java/org/wso2/carbon/identity/application/authenticator/google/GoogleOAuth2AuthenticationConstant.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.google/src/main/java/org/wso2/carbon/identity/application/authenticator/google/GoogleOAuth2AuthenticationConstant.java
@@ -31,5 +31,5 @@ public class GoogleOAuth2AuthenticationConstant {
     public static final String ADDITIONAL_QUERY_PARAMS = "AdditionalQueryParameters";
 
     public static final String OIDC_CLAIM_DIALECT_URI = "http://wso2.org/oidc/claim";
-    public static final String PARAMETER_VALUE_FOR_CLAIM_DIALECT = "GoogleClaimDialectUri";
+    public static final String CLAIM_DIALECT_URI_PARAMETER = "GoogleClaimDialectUri";
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.google/src/main/java/org/wso2/carbon/identity/application/authenticator/google/GoogleOAuth2AuthenticationConstant.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.google/src/main/java/org/wso2/carbon/identity/application/authenticator/google/GoogleOAuth2AuthenticationConstant.java
@@ -29,4 +29,7 @@ public class GoogleOAuth2AuthenticationConstant {
     public static final String GOOGLE_SCOPE = "openid email profile";
     public static final String CALLBACK_URL = "Google-callback-url";
     public static final String ADDITIONAL_QUERY_PARAMS = "AdditionalQueryParameters";
+
+    public static final String OIDC_CLAIM_DIALECT_URI = "http://wso2.org/oidc/claim";
+    public static final String PARAMETER_VALUE_FOR_CLAIM_DIALECT = "GoogleClaimDialectUri";
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.google/src/main/java/org/wso2/carbon/identity/application/authenticator/google/GoogleOAuth2Authenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.google/src/main/java/org/wso2/carbon/identity/application/authenticator/google/GoogleOAuth2Authenticator.java
@@ -17,21 +17,27 @@
  */
 package org.wso2.carbon.identity.application.authenticator.google;
 
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONValue;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.oltu.oauth2.client.response.OAuthClientResponse;
+import org.apache.oltu.oauth2.common.utils.JSONUtils;
 import org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilder;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authenticator.oidc.OIDCAuthenticatorConstants;
 import org.wso2.carbon.identity.application.authenticator.oidc.OpenIDConnectAuthenticator;
+import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
+import org.wso2.carbon.identity.base.IdentityConstants;
+import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.io.IOException;
+import java.util.*;
 
 public class GoogleOAuth2Authenticator extends OpenIDConnectAuthenticator {
 
@@ -228,8 +234,8 @@ public class GoogleOAuth2Authenticator extends OpenIDConnectAuthenticator {
         if (authConfig != null) {
            Map<String, String> parameters = authConfig.getParameterMap();
            if (parameters != null && parameters.containsKey(GoogleOAuth2AuthenticationConstant.
-                   PARAMETER_VALUE_FOR_CLAIM_DIALECT)) {
-               claimDialectUri = parameters.get(GoogleOAuth2AuthenticationConstant.PARAMETER_VALUE_FOR_CLAIM_DIALECT);
+                  CLAIM_DIALECT_URI_PARAMETER)) {
+               claimDialectUri = parameters.get(GoogleOAuth2AuthenticationConstant.CLAIM_DIALECT_URI_PARAMETER);
            } else {
                if (log.isDebugEnabled()) {
                    log.debug("Found no Parameter map for connector " + getName());
@@ -237,9 +243,95 @@ public class GoogleOAuth2Authenticator extends OpenIDConnectAuthenticator {
            }
         } else {
             if (log.isDebugEnabled()) {
-                log.debug("Error Reading Parameters for connector " + getName());
+                log.debug("FileBasedConfigBuilder returned null AuthenticatorConfigs for the connector " +
+                        getName());
             }
         }
         return claimDialectUri;
+    }
+
+    @Override
+    protected void buildClaimMappings(Map<ClaimMapping, String> claims, Map.Entry<String, Object> entry, String separator) {
+        String claimValue = null;
+        String claimUri   = "";
+        if (StringUtils.isBlank(separator)) {
+            separator = IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR_DEFAULT;
+        }
+        try {
+            JSONArray jsonArray = (JSONArray) JSONValue.parseWithException(entry.getValue().toString());
+            if (jsonArray != null && jsonArray.size() > 0) {
+                Iterator attributeIterator = jsonArray.iterator();
+                while (attributeIterator.hasNext()) {
+                    if (claimValue == null) {
+                        claimValue = attributeIterator.next().toString();
+                    } else {
+                        claimValue = claimValue + separator + attributeIterator.next().toString();
+                    }
+                }
+
+            }
+        } catch (Exception e) {
+            claimValue = entry.getValue().toString();
+        }
+        String claimDialectUri = getClaimDialectURI();
+        if (!OIDCAuthenticatorConstants.OIDC_CLAIM_DIALECT_URI.equals(claimDialectUri)) {
+            claimUri = claimDialectUri + "/";
+        }
+
+        claimUri += entry.getKey();
+        claims.put(ClaimMapping.build(claimUri, claimUri, null, false), claimValue);
+        if (log.isDebugEnabled() && IdentityUtil.isTokenLoggable(IdentityConstants.IdentityTokens.USER_CLAIMS)) {
+            log.debug("Adding claim mapping : " + claimUri + " <> " + claimUri + " : " + claimValue);
+        }
+    }
+
+    /**
+     * Get subject attributes.
+     * @param token OAuthClientResponse
+     * @param authenticatorProperties Map<String, String> (Authenticator property, Property value)
+     * @return Map<ClaimMapping, String> Claim mappings.
+     */
+    protected Map<ClaimMapping, String> getSubjectAttributes(OAuthClientResponse token,
+                                                             Map<String, String> authenticatorProperties) {
+
+        Map<ClaimMapping, String> claims = new HashMap<>();
+
+        try {
+            String accessToken = token.getParam(OIDCAuthenticatorConstants.ACCESS_TOKEN);
+            String url = getUserInfoEndpoint(token, authenticatorProperties);
+            String json = sendRequest(url, accessToken);
+
+            if (StringUtils.isBlank(json)) {
+                if(log.isDebugEnabled()) {
+                    log.debug("Empty JSON response from user info endpoint. Unable to fetch user claims." +
+                            " Proceeding without user claims");
+                }
+                return claims;
+            }
+
+            Map<String, Object> jsonObject = JSONUtils.parseJSON(json);
+
+            for (Map.Entry<String, Object> data : jsonObject.entrySet()) {
+                String key = data.getKey();
+                Object value = data.getValue();
+                String claimDialectUri = getClaimDialectURI();
+                if (!OIDCAuthenticatorConstants.OIDC_CLAIM_DIALECT_URI.equals(claimDialectUri)) {
+                    key = claimDialectUri + "/" + key;
+                }
+                if (value != null) {
+                    claims.put(ClaimMapping.build(key, key, null, false), value.toString());
+                }
+
+                if (log.isDebugEnabled() && IdentityUtil.isTokenLoggable(IdentityConstants.IdentityTokens.USER_CLAIMS)
+                        && jsonObject.get(key) != null) {
+                    log.debug("Adding claims from end-point data mapping : " + key + " - " + jsonObject.get(key)
+                            .toString());
+                }
+            }
+        } catch (IOException e) {
+            log.error("Communication error occurred while accessing user info endpoint", e);
+        }
+
+        return claims;
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.google/src/main/java/org/wso2/carbon/identity/application/authenticator/google/GoogleOAuth2Authenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.google/src/main/java/org/wso2/carbon/identity/application/authenticator/google/GoogleOAuth2Authenticator.java
@@ -229,7 +229,7 @@ public class GoogleOAuth2Authenticator extends OpenIDConnectAuthenticator {
 
     @Override
     public String getClaimDialectURI() {
-        String claimDialectUri = GoogleOAuth2AuthenticationConstant.OIDC_CLAIM_DIALECT_URI;
+        String claimDialectUri = super.getClaimDialectURI();
         AuthenticatorConfig authConfig = FileBasedConfigurationBuilder.getInstance().getAuthenticatorBean(getName());
         if (authConfig != null) {
            Map<String, String> parameters = authConfig.getParameterMap();
@@ -246,6 +246,9 @@ public class GoogleOAuth2Authenticator extends OpenIDConnectAuthenticator {
                 log.debug("FileBasedConfigBuilder returned null AuthenticatorConfigs for the connector " +
                         getName());
             }
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Authenticator " + getName() + " is using the claim dialect uri " + claimDialectUri);
         }
         return claimDialectUri;
     }

--- a/components/org.wso2.carbon.identity.application.authenticator.google/src/main/java/org/wso2/carbon/identity/application/authenticator/google/GoogleOAuth2Authenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.google/src/main/java/org/wso2/carbon/identity/application/authenticator/google/GoogleOAuth2Authenticator.java
@@ -18,7 +18,11 @@
 package org.wso2.carbon.identity.application.authenticator.google;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.oltu.oauth2.client.response.OAuthClientResponse;
+import org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilder;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authenticator.oidc.OIDCAuthenticatorConstants;
 import org.wso2.carbon.identity.application.authenticator.oidc.OpenIDConnectAuthenticator;
@@ -32,6 +36,7 @@ import java.util.Map;
 public class GoogleOAuth2Authenticator extends OpenIDConnectAuthenticator {
 
     private static final long serialVersionUID = -4154255583070524018L;
+    private static Log log = LogFactory.getLog(GoogleOAuth2Authenticator.class);
     private String tokenEndpoint;
     private String oAuthEndpoint;
     private String userInfoURL;
@@ -214,5 +219,27 @@ public class GoogleOAuth2Authenticator extends OpenIDConnectAuthenticator {
     @Override
     public String getName() {
         return GoogleOAuth2AuthenticationConstant.GOOGLE_CONNECTOR_NAME;
+    }
+
+    @Override
+    public String getClaimDialectURI() {
+        String claimDialectUri = GoogleOAuth2AuthenticationConstant.OIDC_CLAIM_DIALECT_URI;
+        AuthenticatorConfig authConfig = FileBasedConfigurationBuilder.getInstance().getAuthenticatorBean(getName());
+        if (authConfig != null) {
+           Map<String, String> parameters = authConfig.getParameterMap();
+           if (parameters != null && parameters.containsKey(GoogleOAuth2AuthenticationConstant.
+                   PARAMETER_VALUE_FOR_CLAIM_DIALECT)) {
+               claimDialectUri = parameters.get(GoogleOAuth2AuthenticationConstant.PARAMETER_VALUE_FOR_CLAIM_DIALECT);
+           } else {
+               if (log.isDebugEnabled()) {
+                   log.debug("Found no Parameter map for connector " + getName());
+               }
+           }
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("Error Reading Parameters for connector " + getName());
+            }
+        }
+        return claimDialectUri;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,7 @@
         <oltu.package.import.version.range>[1.0.0, 2.0.0)</oltu.package.import.version.range>
         <json.wso2.version>3.0.0.wso2v1</json.wso2.version>
         <carbon.identity.authenticator.oidc.version>5.1.3</carbon.identity.authenticator.oidc.version>
+        <net.minidev.json.imp.pkg.version.range>[1.3.0, 2.0.0)</net.minidev.json.imp.pkg.version.range>
 
         <!--Maven Plugin Version-->
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>


### PR DESCRIPTION
This PR add the dedicated claim dialect support for google connector. In order to enable this feature add following line in application-authentication.xml
&lt;Parameter name="GoogleClaimDialectUri"&gt;http://wso2.org/google/claims &lt;/Parameter&gt;

public JIRA:- https://wso2.org/jira/browse/IDENTITY-6239